### PR TITLE
Renamed hasListeners to RNStarPrnt_hasListeners to avoid build confli…

### DIFF
--- a/ios/RNStarPrnt.m
+++ b/ios/RNStarPrnt.m
@@ -14,7 +14,7 @@
 
 @implementation RNStarPrnt
 
- bool hasListeners;
+ bool RNStarPrnt_hasListeners;
 
 - (dispatch_queue_t)methodQueue
 {
@@ -29,13 +29,13 @@ RCT_EXPORT_MODULE();
 
 // Will be called when this module's first listener is added.
 -(void)startObserving {
-    hasListeners = YES;
+    RNStarPrnt_hasListeners = YES;
     // Set up any upstream listeners or background tasks as necessary
 }
 
 // Will be called when this module's last listener is removed, or on dealloc.
 -(void)stopObserving {
-    hasListeners = NO;
+    RNStarPrnt_hasListeners = NO;
     // Remove upstream listeners, stop unnecessary background tasks
 }
 
@@ -352,7 +352,7 @@ RCT_REMAP_METHOD(print, portName:(NSString *)portName
         if (data != nil) {
             [dict setObject:data forKey:@"data"];
         }
-     if (hasListeners) {
+     if (RNStarPrnt_hasListeners) {
          [self sendEventWithName:@"starPrntData" body:dict];
      }
 }


### PR DESCRIPTION
…cts in xcode

If another library uses hasListeners, then Xcode gets confused and fails to build the project. Example:

```
duplicate symbol _hasListeners in:
    /Users/jimmy/Library/Developer/Xcode/DerivedData/MyApp-gjwlztxwlgeyipbojfoewcpshknr/Build/Products/Debug-iphoneos/ReactNativeSocketMobile/libReactNativeSocketMobile.a(ReactNativeSocketMobile.o)
    /Users/jimmy/Library/Developer/Xcode/DerivedData/MyApp-gjwlztxwlgeyipbojfoewcpshknr/Build/Products/Debug-iphoneos/libRNStarPrnt.a(RNStarPrnt.o)
```