### PR TITLE
Added requiresMainQueueSetup

### DIFF
--- a/ios/RNStarPrnt.m
+++ b/ios/RNStarPrnt.m
@@ -16,6 +16,11 @@
 
  bool hasListeners;
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (dispatch_queue_t)methodQueue
 {
     return dispatch_queue_create("net.infoxication.react.starprnt", DISPATCH_QUEUE_SERIAL);


### PR DESCRIPTION
React native defaults this value to YES, but I'm not sure if it's right for this library. This should resolve the warning message that you get from react native though.