### PR TITLE
Added the ability to parse a URI with a file scheme on iOS

### DIFF
--- a/ios/RNStarPrnt.m
+++ b/ios/RNStarPrnt.m
@@ -534,8 +534,15 @@ RCT_REMAP_METHOD(print, portName:(NSString *)portName
             BOOL diffusion = ([[command valueForKey:@"diffusion"] boolValue] == NO) ? NO : YES;
             BOOL bothScale = ([[command valueForKey:@"bothScale"] boolValue]  == NO) ? NO : YES;
             SCBBitmapConverterRotation rotation = [self getBitmapConverterRotation:[command valueForKey:@"rotation"]];
+            NSError *error = nil;
             NSURL *imageURL = [NSURL URLWithString:urlString];
-            NSData *imageData = [NSData dataWithContentsOfURL:imageURL];
+            NSData *imageData = [NSData dataWithContentsOfURL:imageURL options:NSDataReadingUncached error:&error];
+
+            if (error != nil) {
+                NSURL *fileImageURL = [NSURL fileURLWithPath:urlString];
+                imageData = [NSData dataWithContentsOfURL:fileImageURL];
+            }
+
             UIImage *image = [UIImage imageWithData:imageData];
             
             if([command valueForKey:@"absolutePosition"]){


### PR DESCRIPTION
The current implementation on iOS does not appear to support parsing a URI with a file scheme whereas the Android implementation does. This change will fallback to attempting to parse and re-invoke dataWithContentsOfURL with a file based URL if URLWithString fails due to urlString being a file path.