### PR TITLE
Move `requiresMainQueueSetup` to after `methodQueue`

### DIFF
--- a/ios/RNStarPrnt.m
+++ b/ios/RNStarPrnt.m
@@ -16,14 +16,14 @@
 
  bool RNStarPrnt_hasListeners;
 
-+ (BOOL)requiresMainQueueSetup
-{
-    return YES;
-}
-
 - (dispatch_queue_t)methodQueue
 {
     return dispatch_queue_create("net.infoxication.react.starprnt", DISPATCH_QUEUE_SERIAL);
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
 }
 RCT_EXPORT_MODULE();
 


### PR DESCRIPTION
Move `requiresMainQueueSetup` to after `methodQueue` to fix warning about main queue.
Fixes issue #33 