### PR TITLE
Fix homepage attribute with github repository page

### DIFF
--- a/ios/RNStarPrnt.podspec
+++ b/ios/RNStarPrnt.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNStarPrnt
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/infoxicator/react-native-star-prnt"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
A quick fix to make `pod install` command run successfully.